### PR TITLE
Fix a bug in which aco_struct.color[i] can be null

### DIFF
--- a/src/aco2html.js
+++ b/src/aco2html.js
@@ -179,7 +179,7 @@ var Aco = (function() {
 
                 if (rgb == null) continue;
 
-                aco.color[j] = rgb;
+                aco.color.push(rgb);
 
             }
             return aco;


### PR DESCRIPTION
Hey, I know this project is old, but possibly still quite useful.

I attempted to convert an ACO file and it failed because one of the colours failed to decode, creating a hole in the `aco_struct.color` array. This PR ensures that the aforementioned array does not have any holes.